### PR TITLE
[Bug Fix] Minor bug fix in the useDimensions() composable.

### DIFF
--- a/src/composables/useDimensions/index.ts
+++ b/src/composables/useDimensions/index.ts
@@ -37,8 +37,8 @@ export const useDimensions = () => {
 
   const dimensions = computed<Cartesian2DCoordinate>(() => {
     return {
-      x: x.value,
-      y: y.value
+      x: x.value * resolution.value,
+      y: y.value * resolution.value
     }
   })
 


### PR DESCRIPTION
[Bug Fix] Minor bug fix in the useDimensions() composable: essentially the computed dimensions value needed to be multiplied by the resolution of the screen.