### PR TITLE
[Bugfix] Remove async in onMounted() call in useStars() composable.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@observerly/aestrium",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@observerly/aestrium",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@observerly/celestia": "^0.19.1",
         "@observerly/useaestrium": "^0.10.0",
         "@vueuse/core": "^7.3.0",
         "@vueuse/gesture": "^1.0.0",
-        "vue": "^3.2.25"
+        "vue": "^3.2.26"
       },
       "devDependencies": {
         "@rollup/plugin-typescript": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@observerly/useaestrium": "^0.10.0",
     "@vueuse/core": "^7.3.0",
     "@vueuse/gesture": "^1.0.0",
-    "vue": "^3.2.25"
+    "vue": "^3.2.26"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^8.3.0",

--- a/src/composables/useStars/index.ts
+++ b/src/composables/useStars/index.ts
@@ -195,24 +195,35 @@ export const useStars = (options: UseStarsOptions) => {
     y
   } = options
 
-  const stars = ref<Star[]>([])
-
   const majorStars = ref([])
+
+  const fetchMajorStars = async () => {
+    const response = await fetch('https://observerly.com/api/v2/stars/major')
+    majorStars.value = await response.json()
+  }
 
   const minorStars = ref([])
 
+  const fetchMinorStars = async () => {
+    const response = await fetch('https://observerly.com/api/v2/stars/minor')
+    minorStars.value = await response.json()
+  }
+
+  onMounted(() => {
+    fetchMajorStars()
+    fetchMinorStars()
+  })
+
   const { limit, scaling } = useMagnitude()
 
-  onMounted(async () => {
-    majorStars.value = await fetchMajorStars()
-    minorStars.value = await fetchMinorStars()
-    stars.value = [...majorStars.value, ...minorStars.value].filter(
+  const intersectingRadius = ref(30)
+
+  const stars = computed<Star[]>(() => {
+    return [...majorStars.value, ...minorStars.value].filter(
       (s: Star) =>
         parseFloat(s.apparentMagnitude) <= limit.value && (hasBayer(s) || hasIAU(s))
     )
   })
-
-  const intersectingRadius = ref(30)
 
   const _s = computed<StarObservedRelativeExtended[]>(() => {
     const width = dimensions.value.x


### PR DESCRIPTION
[Bugfix] Implementing possible solution to remove async onMounted() call in useStars() composable. Includes upgrading vue@next version to 3.2.26.