### PR TITLE
chore: Upgraded @observerly/celestia => @observerly/polaris dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Vue 3 component module written in modern Typescript (strongly typed Javascript).
 
-aestrium-vue utilises the celestia astrometric library: [@observerly/celestia](https://github.com/observerly/celestia)
+aestrium-vue utilises the polaris astrometric library: [@observerly/polaris](https://github.com/observerly/p[olaris]) by observerly.
 
 ## Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@observerly/polaris": "^0.52.1",
-        "@observerly/useaestrium": "^0.11.3",
+        "@observerly/useaestrium": "^0.12.0",
         "@vueuse/core": "^7.4.1",
         "@vueuse/gesture": "^1.0.0",
         "vue": "^3.2.26"
@@ -176,27 +176,26 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@observerly/celestia": {
-      "version": "0.19.3",
-      "resolved": "https://npm.pkg.github.com/download/@observerly/celestia/0.19.3/cc5e7c4a95e852e49ed391255b887e743f41cefa40c411f0d8c1c1245bce1ad9",
-      "integrity": "sha512-zr0MNdBgVhsQyk84PYQ6GyqKBFwY0b/hnO/4gcsUCNazsM13CZfAT6IEVibTgcZGftW38rP/eqBdDZPyIhaNDw==",
-      "license": "ISC"
-    },
     "node_modules/@observerly/polaris": {
       "version": "0.52.1",
       "resolved": "https://npm.pkg.github.com/download/@observerly/polaris/0.52.1/2bfc7be2b992b8823a1e63774e30218bd0615f96afead02d76475b33b3c9ead3",
       "integrity": "sha512-e62MHVgwiHtBlhkgHmhHcB7/wV4RTX297hVASY4oswkPx8+y1P0dq6tyIqGn08zRSeBSmL6EhUteIsaWEU2Dsw=="
     },
     "node_modules/@observerly/useaestrium": {
-      "version": "0.11.3",
-      "resolved": "https://npm.pkg.github.com/download/@observerly/useaestrium/0.11.3/772c90fceb706afcb555d0d567f37df00a6a9d0e904fe2d6e2cfaff9e1647175",
-      "integrity": "sha512-FCtxdcVdP36fTXiDC4sETLVVaMc6le+L/J2PVcWT0o/6qZtvWmPQwe55mOjuXZvz4w6nnHiRDcg9/pZ1/wEWpQ==",
+      "version": "0.12.0",
+      "resolved": "https://npm.pkg.github.com/download/@observerly/useaestrium/0.12.0/4030df96f39d72fe0e1a6abd319cb2315b7fb1e36b57021092c178b3ea5ed5f4",
+      "integrity": "sha512-hOMOqB5cjiXvh3easwSLHYkl6BnPu4bCZ8c041z9gG46tUzyMmmC5Z4Z3VBK3QJTXjVjQStHc0OmTgrptJOplg==",
       "license": "ISC",
       "dependencies": {
-        "@observerly/celestia": "^0.19.3",
+        "@observerly/polaris": "^0.53.0",
         "@vueuse/core": "^7.4.1",
         "vue": "^3.2.26"
       }
+    },
+    "node_modules/@observerly/useaestrium/node_modules/@observerly/polaris": {
+      "version": "0.53.0",
+      "resolved": "https://npm.pkg.github.com/download/@observerly/polaris/0.53.0/7bfff59d87d51cfe2a229942b8d3b756831feede29f252d89d3eb69b9eb8f5a9",
+      "integrity": "sha512-QvtQ1O0XaoqciDvb4pGMDl2FPoF7SAJZ55Cm7n94RsF96HNRbxXsPlqyHnqKppHF96UrlDOhRITpMnCjbZxCVw=="
     },
     "node_modules/@rollup/plugin-typescript": {
       "version": "8.3.0",
@@ -3083,24 +3082,26 @@
         "fastq": "^1.6.0"
       }
     },
-    "@observerly/celestia": {
-      "version": "0.19.3",
-      "resolved": "https://npm.pkg.github.com/download/@observerly/celestia/0.19.3/cc5e7c4a95e852e49ed391255b887e743f41cefa40c411f0d8c1c1245bce1ad9",
-      "integrity": "sha512-zr0MNdBgVhsQyk84PYQ6GyqKBFwY0b/hnO/4gcsUCNazsM13CZfAT6IEVibTgcZGftW38rP/eqBdDZPyIhaNDw=="
-    },
     "@observerly/polaris": {
       "version": "0.52.1",
       "resolved": "https://npm.pkg.github.com/download/@observerly/polaris/0.52.1/2bfc7be2b992b8823a1e63774e30218bd0615f96afead02d76475b33b3c9ead3",
       "integrity": "sha512-e62MHVgwiHtBlhkgHmhHcB7/wV4RTX297hVASY4oswkPx8+y1P0dq6tyIqGn08zRSeBSmL6EhUteIsaWEU2Dsw=="
     },
     "@observerly/useaestrium": {
-      "version": "0.11.3",
-      "resolved": "https://npm.pkg.github.com/download/@observerly/useaestrium/0.11.3/772c90fceb706afcb555d0d567f37df00a6a9d0e904fe2d6e2cfaff9e1647175",
-      "integrity": "sha512-FCtxdcVdP36fTXiDC4sETLVVaMc6le+L/J2PVcWT0o/6qZtvWmPQwe55mOjuXZvz4w6nnHiRDcg9/pZ1/wEWpQ==",
+      "version": "0.12.0",
+      "resolved": "https://npm.pkg.github.com/download/@observerly/useaestrium/0.12.0/4030df96f39d72fe0e1a6abd319cb2315b7fb1e36b57021092c178b3ea5ed5f4",
+      "integrity": "sha512-hOMOqB5cjiXvh3easwSLHYkl6BnPu4bCZ8c041z9gG46tUzyMmmC5Z4Z3VBK3QJTXjVjQStHc0OmTgrptJOplg==",
       "requires": {
-        "@observerly/celestia": "^0.19.3",
+        "@observerly/polaris": "^0.53.0",
         "@vueuse/core": "^7.4.1",
         "vue": "^3.2.26"
+      },
+      "dependencies": {
+        "@observerly/polaris": {
+          "version": "0.53.0",
+          "resolved": "https://npm.pkg.github.com/download/@observerly/polaris/0.53.0/7bfff59d87d51cfe2a229942b8d3b756831feede29f252d89d3eb69b9eb8f5a9",
+          "integrity": "sha512-QvtQ1O0XaoqciDvb4pGMDl2FPoF7SAJZ55Cm7n94RsF96HNRbxXsPlqyHnqKppHF96UrlDOhRITpMnCjbZxCVw=="
+        }
       }
     },
     "@rollup/plugin-typescript": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@observerly/polaris": "^0.52.1",
-    "@observerly/useaestrium": "^0.11.3",
+    "@observerly/useaestrium": "^0.12.0",
     "@vueuse/core": "^7.4.1",
     "@vueuse/gesture": "^1.0.0",
     "vue": "^3.2.26"

--- a/src/composables/useEcliptic/index.ts
+++ b/src/composables/useEcliptic/index.ts
@@ -2,13 +2,10 @@ import { computed, ref, ComputedRef, Ref } from 'vue'
 
 import { onKeyStroke } from '@vueuse/core'
 
-import {
-  Cartesian2DHorizontalCoordinate,
-} from '@observerly/celestia'
-
 import type {
   CartesianCoordinate,
-  EquatorialCoordinate
+  EquatorialCoordinate,
+  HorizontalCoordinate
 } from '@observerly/polaris'
 
 import {
@@ -16,6 +13,8 @@ import {
   convertHorizontalToStereo,
   getSolarEcliptic
 } from '@observerly/polaris'
+
+export type EclipticCoordinate = CartesianCoordinate & EquatorialCoordinate & HorizontalCoordinate
 
 export interface UseEclipticOptions {
   /**
@@ -106,7 +105,7 @@ export const useEcliptic = (options: UseEclipticOptions) => {
     }
   )
 
-  const ecliptic = computed<Cartesian2DHorizontalCoordinate[]>(() => {
+  const ecliptic = computed<EclipticCoordinate[]>(() => {
     const ecliptic: EquatorialCoordinate[] = getSolarEcliptic(datetime.value)
 
     const width = dimensions.value.x
@@ -163,7 +162,7 @@ export const useEcliptic = (options: UseEclipticOptions) => {
     if (ctx.value) {
       const precision = resolution.value
 
-      ecliptic.value.forEach((coordinate: Cartesian2DHorizontalCoordinate) => {
+      ecliptic.value.forEach((coordinate: EclipticCoordinate) => {
         const { x, y } = coordinate
 
         if (x >= 0 && y >= 0 && ctx.value) {

--- a/src/composables/useInteractions/index.ts
+++ b/src/composables/useInteractions/index.ts
@@ -43,9 +43,9 @@ export const useInteractions = (options: UseInteractionsOptions) => {
 
   useDrag(
     ({ tap, dragging }): void => {
-      // Are we tapping the Celestia Sky Viewer frame?
+      // Are we tapping the Sky Viewer frame?
       isTapping.value = tap
-      // Are we dragging the Celestia Sky Viewer frame?
+      // Are we dragging the Sky Viewer frame?
       isDragging.value = dragging
     },
     {

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -1,4 +1,4 @@
-import { Cartesian2DCoordinate } from '@observerly/celestia'
+import { CartesianCoordinate } from '@observerly/polaris'
 
 /**
  * 
@@ -61,8 +61,8 @@ export const drawClosedPath = (
  */
 export const drawLine = (
   ctx: OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D | null,
-  moveTo: Cartesian2DCoordinate,
-  lineTo: Cartesian2DCoordinate
+  moveTo: CartesianCoordinate,
+  lineTo: CartesianCoordinate
 ): void => {
   if (ctx) {
     ctx.beginPath()

--- a/src/utils/intersectDistance.ts
+++ b/src/utils/intersectDistance.ts
@@ -1,6 +1,6 @@
 import type {
-  Cartesian2DCoordinate
-} from '@observerly/celestia'
+  CartesianCoordinate
+} from '@observerly/polaris'
 
 /**
  * intersectDistance()
@@ -11,6 +11,6 @@ import type {
  * @param coordinate
  * @returns distance between position i and position j
  */
-export const intersectDistance = (i: Cartesian2DCoordinate, j: Cartesian2DCoordinate): number => {
+export const intersectDistance = (i: CartesianCoordinate, j: CartesianCoordinate): number => {
   return Math.sqrt((i.x - j.x) ** 2 + (i.y - j.y) ** 2)
 }


### PR DESCRIPTION
chore: Upgraded @observerly/celestia => @observerly/polaris dependency. 

Includes bumping @observerly/useaestrium version => 0.12.0 to fully deprecate celestia dependency.

Includes associated non-breaking changes to code.