### PR TITLE
fix: Removed redundant external dependency from rollupOptions in vite.lib.config.ts.

### DIFF
--- a/vite.lib.config.ts
+++ b/vite.lib.config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
       fileName: format => `aestrium.${format}.js`
     },
     rollupOptions: {
-      external: ['vue', '@observerly/polaris', '@observerly/useaestrium'],
+      external: ['vue', '@observerly/polaris'],
       output: {
         sourcemap: false,
         // Provide global variables to use in the UMD build


### PR DESCRIPTION
fix: Removed redundant external dependency from rollupOptions in vite.lib.config.ts.